### PR TITLE
Rule engine

### DIFF
--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/ToggleStatusesServiceImpl.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/ToggleStatusesServiceImpl.java
@@ -3,15 +3,21 @@ package com.linkedin.openhouse.housetables.services;
 import com.linkedin.openhouse.common.api.spec.ToggleStatusEnum;
 import com.linkedin.openhouse.housetables.api.spec.model.ToggleStatus;
 import com.linkedin.openhouse.housetables.repository.impl.jdbc.ToggleStatusHtsJdbcRepository;
+import com.linkedin.openhouse.housetables.services.toggle.TableRuleEngine;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ToggleStatusesServiceImpl implements ToggleStatusesService {
   @Autowired ToggleStatusHtsJdbcRepository htsRepository;
+  @Autowired TableRuleEngine tableRuleEngine;
 
   @Override
   public ToggleStatus getTableToggleStatus(String featureId, String databaseId, String tableId) {
-    return ToggleStatus.builder().status(ToggleStatusEnum.ACTIVE).build();
+    boolean evalResult =
+        tableRuleEngine.eval(databaseId, tableId, htsRepository.findAllByFeature(featureId));
+    return evalResult
+        ? ToggleStatus.builder().status(ToggleStatusEnum.ACTIVE).build()
+        : ToggleStatus.builder().status(ToggleStatusEnum.INACTIVE).build();
   }
 }

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/toggle/RegexSimpleRuleEngine.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/toggle/RegexSimpleRuleEngine.java
@@ -1,0 +1,30 @@
+package com.linkedin.openhouse.housetables.services.toggle;
+
+import com.linkedin.openhouse.housetables.model.TableToggleRule;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RegexSimpleRuleEngine implements TableRuleEngine {
+  @Override
+  public boolean eval(String databaseId, String tableId, Iterable<TableToggleRule> rules) {
+    // base version of the rule engine just iterate through all existing rules
+    // and return positive when hitting the first match
+    for (TableToggleRule rule : rules) {
+      if (regexMatch(rule.getDatabasePattern(), databaseId)
+          && regexMatch(rule.getTablePattern(), tableId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Regex-based matching */
+  private boolean regexMatch(String rulePattern, String entityId) {
+    Pattern pattern = Pattern.compile(rulePattern);
+    Matcher matcher = pattern.matcher(entityId);
+
+    return matcher.matches();
+  }
+}

--- a/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/toggle/TableRuleEngine.java
+++ b/services/housetables/src/main/java/com/linkedin/openhouse/housetables/services/toggle/TableRuleEngine.java
@@ -1,0 +1,7 @@
+package com.linkedin.openhouse.housetables.services.toggle;
+
+import com.linkedin.openhouse.housetables.model.TableToggleRule;
+
+public interface TableRuleEngine {
+  boolean eval(String databaseId, String tableId, Iterable<TableToggleRule> rules);
+}

--- a/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/togglerule/RegexSimpleRuleEngineTest.java
+++ b/services/housetables/src/test/java/com/linkedin/openhouse/housetables/e2e/togglerule/RegexSimpleRuleEngineTest.java
@@ -1,0 +1,28 @@
+package com.linkedin.openhouse.housetables.e2e.togglerule;
+
+import com.google.common.collect.ImmutableList;
+import com.linkedin.openhouse.housetables.model.TableToggleRule;
+import com.linkedin.openhouse.housetables.services.toggle.RegexSimpleRuleEngine;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RegexSimpleRuleEngineTest {
+
+  @Test
+  public void testRegexRuleEngine() {
+    RegexSimpleRuleEngine ruleEngine = new RegexSimpleRuleEngine();
+    List<TableToggleRule> toggleRuleList =
+        ImmutableList.of(
+            TableToggleRule.builder().databasePattern("db").tablePattern("table").build(),
+            TableToggleRule.builder().databasePattern("nyc.*").tablePattern("table").build(),
+            TableToggleRule.builder().databasePattern("^a.*|^b.*").tablePattern(".*").build());
+
+    Assertions.assertTrue(ruleEngine.eval("db", "table", toggleRuleList));
+    Assertions.assertTrue(ruleEngine.eval("nycaa", "table", toggleRuleList));
+    Assertions.assertFalse(ruleEngine.eval("nyc123", "able", toggleRuleList));
+    Assertions.assertTrue(ruleEngine.eval("a5", "table", toggleRuleList));
+    Assertions.assertTrue(ruleEngine.eval("b4", "table", toggleRuleList));
+    Assertions.assertFalse(ruleEngine.eval("ccc", "table", toggleRuleList));
+  }
+}


### PR DESCRIPTION
## Summary

<!--- HINT: Replace #nnn with corresponding Issue number, if you are fixing an existing issue -->
This PR just adds a rule-engine within HTS so that when inserting rules into MySQL, one can use regex to avoid listing all tables involved in a feature-activation. 


## Changes

- [ ] Client-facing API Changes
- [ ] Internal API Changes
- [ ] Bug Fixes
- [x] New Features
- [ ] Performance Improvements
- [ ] Code Style
- [ ] Refactoring
- [ ] Documentation
- [ ] Tests

For all the boxes checked, please include additional details of the changes made in this pull request.  

## Testing
<!--- Check any relevant boxes with "x" -->

- [ ] Manually Tested on local docker setup. Please include commands ran, and their output.
- [x] Added new tests for the changes made.
- [ ] Updated existing tests to reflect the changes made.
- [ ] No tests added or updated. Please explain why. If unsure, please feel free to ask for help.
- [ ] Some other form of testing like staging or soak time in production. Please explain.

For all the boxes checked, include a detailed description of the testing done for the changes made in this pull request.

# Additional Information

- [ ] Breaking Changes
- [ ] Deprecations
- [ ] Large PR broken into smaller PRs, and PR plan linked in the description.

For all the boxes checked, include additional details of the changes made in this pull request.